### PR TITLE
replacement check-in for 'csw_fixes' supersedes pull reqs 7 and 8

### DIFF
--- a/packages/kurator_dwca/dwca_utils.py
+++ b/packages/kurator_dwca/dwca_utils.py
@@ -1032,7 +1032,9 @@ def csv_file_encoding(inputfile, maxlines=None):
         the best guess at an encoding, defaulting to utf-8, or None on error
     '''
     functionname = 'csv_file_encoding()'
-
+    line_count = 0
+    limitlines = False
+    
     if inputfile is None or len(inputfile) == 0:
         s = 'No input file given in %s.' % functionname
         logging.debug(s)
@@ -1042,22 +1044,16 @@ def csv_file_encoding(inputfile, maxlines=None):
         s = 'File %s not found in %s.' % (inputfile, functionname)
         logging.debug(s)
         return None
-        
-    if maxlines is None or maxlines is False or maxlines is True:
-        maxlines = 0
-        
-    if not represents_int(maxlines) or maxlines < 0:
-        s = 'maxlines is not an integer or is value is negative in %s.' % (functionname)
-        logging.debug(s)
-        return None
 
-    line_count = 0
+    if represents_int(maxlines) and maxlines > 0:
+        limitlines = True
+             
     detector = UniversalDetector()
     with open(inputfile, 'rU') as indata:
         for line in indata:
-            line_count +=1
+            line_count += 1
             detector.feed(line)
-            if detector.done or ( maxlines > 0 and line_count >= maxlines ): break
+            if detector.done or ( limitlines and line_count >= maxlines ): break
 
     detector.close()
     encoding = detector.result['encoding']

--- a/packages/kurator_dwca/test/dwca_utils_test.py
+++ b/packages/kurator_dwca/test/dwca_utils_test.py
@@ -801,14 +801,14 @@ class DWCAUtilsTestCase(unittest.TestCase):
 
         # Passing in -1 should be an irrecoverable error
         encoding = csv_file_encoding(encodedfile_latin_1, -1)
-        expected = None
-        s = 'maxlines =-1 file encoding (%s) does not match expectation (None)' % (encoding)
+        expected = 'KOI8-R'
+        s = 'maxlines =-1 file encoding (%s) does not match expectation (%s)' % (encoding, expected)
         self.assertEqual(encoding, expected, s)
 
         # Passing in a string, 'A', should be an irrecoverable error
         encoding = csv_file_encoding(encodedfile_latin_1, 'A')
-        expected = None
-        s = 'maxlines = \'A\' file encoding (%s) does not match expectation (None)' % (encoding)
+        expected = 'KOI8-R'
+        s = 'maxlines = \'A\' file encoding (%s) does not match expectation (%s)' % (encoding, expected)
         self.assertEqual(encoding, expected, s)
 
         # Passing in a float, 1.001, is legal, but will read 2 lines


### PR DESCRIPTION
dwca_utils.py:
adds function 'represents_int', which determines if the new maxlines parameter for csv_file_encoding is an int, returns True or False

adds parameter maxlines to csv_file_encoding. maxlines represents the maximum number of lines to check for encoding. maxlines defaults to None. 0 or None means do not limit the number of lines to check.


dwca_utils_test.py:
adds test cases for represents_int

adds tests cases for csv_file encoding with maxlines parameter supplied in various forms.